### PR TITLE
Replace dayjs usage with native Date helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "dependencies": {
         "aos": "^2.3.4",
         "bootstrap": "^5.3.3",
-        "dayjs": "^1.11.19",
         "dexie": "^4.2.1",
         "react": "^18.3.1",
         "react-bootstrap": "^2.10.5",
@@ -3586,12 +3585,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.19",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.19.tgz",
-      "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
   "dependencies": {
     "aos": "^2.3.4",
     "bootstrap": "^5.3.3",
-    "dayjs": "^1.11.19",
     "dexie": "^4.2.1",
     "react": "^18.3.1",
     "react-bootstrap": "^2.10.5",

--- a/src/data/dal.js
+++ b/src/data/dal.js
@@ -1,5 +1,4 @@
 import db from './db.js';
-import dayjs from 'dayjs';
 
 /**
  * Data Access Layer - Abstraction for data sources
@@ -83,7 +82,9 @@ class JSONDataProvider {
       
       // If data exists and was synced recently (within 24 hours), skip reload
       if (lastSync && talksCount > 0) {
-        const hoursSinceSync = dayjs().diff(dayjs(lastSync.value), 'hour');
+        const lastSyncDate = new Date(lastSync.value);
+        const now = new Date();
+        const hoursSinceSync = (now.getTime() - lastSyncDate.getTime()) / (1000 * 60 * 60);
         if (hoursSinceSync < 24) {
           this.initialized = true;
           return;

--- a/src/features/agenda/AgendaList.jsx
+++ b/src/features/agenda/AgendaList.jsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { Row, Col, Modal } from 'react-bootstrap';
-import dayjs from 'dayjs';
 
 /**
  * AgendaList Component - Displays a list of talks with favorite functionality
@@ -22,11 +21,19 @@ const AgendaList = ({ talks, isFavorite, onToggleFavorite }) => {
   };
 
   const formatTime = (timeISO) => {
-    return dayjs(timeISO).format('HH:mm');
+    return new Date(timeISO).toLocaleTimeString('es-ES', {
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false
+    });
   };
 
   const formatDate = (timeISO) => {
-    return dayjs(timeISO).format('DD/MM/YYYY');
+    return new Date(timeISO).toLocaleDateString('es-ES', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric'
+    });
   };
 
   const handleToggleFavorite = (e, talkId) => {


### PR DESCRIPTION
## Summary
- replace dayjs usage in the data access layer and agenda list with native Date APIs
- remove the unused dayjs dependency from the project manifest and lockfile

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_690a0be37188833282916ac79f0cc33b