### PR TITLE
feat(dubai-symmetry): unify Madrid/Dubai architecture and sponsorship…

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,10 +4,10 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/png" href="/src/assets/xops.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>X-Ops</title>
+    <title>X-Ops Conference &amp; Summit 2026 · Madrid y Dubai</title>
     
     <!-- PWA Meta Tags -->
-    <meta name="description" content="Únete a la revolución X-Ops! Conferencia sobre DevOps, DevSecOps, ML Ops, AI Ops y transformación digital en Madrid." />
+    <meta name="description" content="X-Ops Conference &amp; Summit 2026 en Madrid y Dubai: Summit ejecutivo y Conference técnica para líderes de tecnología." />
     <meta name="theme-color" content="#005DAA" />
     <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -2,7 +2,7 @@ import 'bootstrap/dist/css/bootstrap.min.css';
 import logo from "./assets/xops.png";
 import bgMain from "./assets/bg-main.jpg";
 import { BsCalendar3, BsChevronDown } from 'react-icons/bs';
-import { Route, Routes, Link, NavLink, Navigate } from 'react-router-dom';
+import { Route, Routes, Link, NavLink, Navigate, useLocation } from 'react-router-dom';
 import { Navbar, Nav, NavDropdown } from 'react-bootstrap';
 import ScrollHandler from './ScrollHandler';
 import { usePWA } from './hooks/usePWA';
@@ -55,6 +55,7 @@ import { useTranslation } from 'react-i18next';
 
 function App() {
   const { t, i18n } = useTranslation();
+  const location = useLocation();
   const { canPrompt, promptInstall } = usePWA();
   const [showCookiePreferences, setShowCookiePreferences] = useState(false);
   const [showTicketModal, setShowTicketModal] = useState(false);
@@ -89,6 +90,8 @@ function App() {
   const handleCloseCookiePreferences = () => {
     setShowCookiePreferences(false);
   };
+
+  const isDubaiEventRoute = location.pathname.startsWith('/events/x-ops-conference-dubai-2026');
 
   return (
   <HelmetProvider>
@@ -243,7 +246,7 @@ function App() {
           <Route path="/speaker/:id" element={<SpeakerPage />} />
           <Route path="/mi-agenda" element={<MyAgenda />} />
 
-          /* Post-Event */
+          {/* Post-Event */}
           <Route path="/post-event" element={<PostEventPage />} />
 
           {/* Analytics Dashboard */}
@@ -285,8 +288,8 @@ function App() {
         <div className="row">
           <div className="col-md-4 mb-3">
             <h5 className='heading'>{t('footer.address')}</h5>
-            <p>{t('footer.addressLine1')}</p>
-            <p>{t('footer.addressLine2')}</p>
+            <p>{isDubaiEventRoute ? t('footer.dubaiAddressLine1') : t('footer.addressLine1')}</p>
+            <p>{isDubaiEventRoute ? t('footer.dubaiAddressLine2') : t('footer.addressLine2')}</p>
           </div>
           <div className="col-md-4 mb-3">
             <h5 className='heading'>{t('footer.contacts')}</h5>

--- a/src/components/EditionsSection.jsx
+++ b/src/components/EditionsSection.jsx
@@ -189,7 +189,7 @@ const EditionsSection = () => {
         <AnimationWrapper animation="fade-up" duration={1000}>
           <div className="text-center mb-5">
             <span style={{ color: '#00BCD4', fontSize: '0.72rem', fontWeight: 700, letterSpacing: '0.24em', textTransform: 'uppercase' }}>
-              // {t('editions.sectionPrefix')}
+              {t('editions.sectionPrefix')}
             </span>
             <h2 style={{ color: '#ffffff', fontWeight: 800, marginTop: '12px', marginBottom: '16px', fontSize: '2rem' }}>
               {t('editions.title')}
@@ -263,9 +263,9 @@ const EditionsSection = () => {
                 t('editions.dubai.badges.region'),
               ]}
               ctaSummit={t('editions.dubai.cta.summit')}
-              ctaSummitTo="/events/x-ops-conference-dubai-2026"
+              ctaSummitTo="/events/x-ops-conference-dubai-2026#summit-dubai"
               ctaConference={t('editions.dubai.cta.conference')}
-              ctaConferenceTo="/events/x-ops-conference-dubai-2026"
+              ctaConferenceTo="/events/x-ops-conference-dubai-2026#conference-dubai"
               targetDate="2026-10-15T09:00:00"
               animDir="left"
             />

--- a/src/components/PricingTable.jsx
+++ b/src/components/PricingTable.jsx
@@ -1,206 +1,267 @@
-import React from 'react';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import { BsCheckCircleFill, BsStar } from 'react-icons/bs';
 import AnimationWrapper from './AnimationWrapper';
 
 const CONTACT_EMAIL = 'info@xopsconference.com';
+const EUR_TO_AED = 4.0;
+const EUR_TO_USD = 1.1;
+const ROUND_STEP = 50;
+const COMBINED_DISCOUNT = 0.1;
 
-const formatPrice = (price) => price.toLocaleString('es-ES');
+const roundToStep = (value, step = ROUND_STEP) => Math.round(value / step) * step;
+const formatNumber = (value) => value.toLocaleString('es-ES');
 
-const platinum = {
-  id: 'platinum',
-  name: 'PLATINUM',
-  price: 10000,
-  features: [
-    'Todos los beneficios del Track Sponsor',
-    'Charla Principal (Keynote) de 30 minutos',
-    'Stand Físico grande (3×2m) en posición estratégica',
-    'Logo en email de bienvenida a asistentes',
-    'Agradecimiento en ceremonia de apertura y clausura',
-    '15 Entradas completas',
-  ],
-};
-
-const track = {
-  id: 'track',
-  name: 'TRACK SPONSOR',
-  price: 6000,
-  features: [
-    'Todos los beneficios del paquete Gold',
-    'Derechos de Nomenclatura del Track',
-    'Branding exclusivo en la sala física',
-    'Logo en cabecera de la agenda del track',
-    'Mención especial al inicio de cada jornada',
-    'Stand Virtual Premium en posición destacada',
-    '15 Entradas completas',
-  ],
-};
-
-const standard = [
+const plans = [
+  {
+    id: 'platinum',
+    name: 'PLATINUM',
+    eurPrice: 10000,
+    featured: true,
+    features: [
+      'Todos los beneficios del Track Sponsor',
+      'Charla Principal (Keynote) de 30 minutos',
+      'Stand físico premium en posición estratégica',
+      'Logo en email de bienvenida a asistentes',
+      'Agradecimiento en ceremonia de apertura y clausura',
+      '15 entradas completas',
+    ],
+  },
+  {
+    id: 'track',
+    name: 'TRACK SPONSOR',
+    eurPrice: 6000,
+    track: true,
+    features: [
+      'Todos los beneficios del paquete Gold',
+      'Derechos de nomenclatura del track',
+      'Branding exclusivo en sala física',
+      'Logo en cabecera de la agenda del track',
+      'Mención especial al inicio de cada jornada',
+      '15 entradas completas',
+    ],
+  },
   {
     id: 'gold',
     name: 'GOLD',
-    price: 3000,
+    eurPrice: 3000,
     features: [
       'Todos los beneficios del paquete Silver',
       'Charla técnica de 45 minutos',
       'Logo destacado en posición superior',
       'Publicación dedicada en redes sociales',
-      'Stand Virtual Mejorado con vídeo y formulario',
-      '10 Entradas completas',
+      '10 entradas completas',
     ],
   },
   {
     id: 'silver',
     name: 'SILVER',
-    price: 1500,
+    eurPrice: 1500,
     features: [
-      'Stand Físico de 2×2m con mesa y sillas',
-      'Stand Virtual Básico',
+      'Stand físico de 2x2m con mesa y sillas',
       'Logo, descripción y enlace web',
       "Logo en sección 'Silver Sponsors'",
       'Mención en publicación conjunta en redes sociales',
-      '5 Entradas completas',
+      '5 entradas completas',
     ],
   },
   {
     id: 'virtual',
     name: 'VIRTUAL-ONLY',
-    price: 1000,
+    eurPrice: 1000,
     features: [
-      'Stand Virtual Premium',
+      'Stand virtual premium',
       'Perfil completo en la aplicación web',
       'Logo, descripción y enlaces a redes sociales',
       'Vídeo promocional incrustado',
-      'Chat en tiempo real con asistentes',
       'Formulario integrado para captura de leads',
-      "Logo en sección 'Virtual Sponsors' de la web",
     ],
   },
 ];
 
-const PricingTable = () => (
-  <section className="sponsor-tiers" id="patrocinio" aria-labelledby="sponsor-tiers-heading">
-    <div className="sponsor-tiers__container">
+const cityModes = [
+  {
+    id: 'madrid',
+    label: 'Patrocina Madrid',
+    currencySymbol: '€',
+    currencyCode: 'EUR',
+    copy: 'Beneficios presenciales aplicados a Madrid.',
+    computePrice: (eur) => eur,
+    subjectPrefix: 'Madrid',
+  },
+  {
+    id: 'dubai',
+    label: 'Patrocina Dubai',
+    currencySymbol: 'AED',
+    currencyCode: 'AED',
+    copy: 'Beneficios presenciales aplicados a Dubai.',
+    computePrice: (eur) => roundToStep(eur * EUR_TO_AED),
+    subjectPrefix: 'Dubai',
+  },
+  {
+    id: 'both',
+    label: 'Patrocina ambas ciudades',
+    currencySymbol: 'US$',
+    currencyCode: 'USD',
+    copy: 'Presencia en Madrid + Dubai con 10% de descuento combinado.',
+    computePrice: (eur) => roundToStep(eur * 2 * EUR_TO_USD * (1 - COMBINED_DISCOUNT)),
+    subjectPrefix: 'Madrid+Dubai',
+  },
+];
 
-      <header className="sponsor-tiers__header">
-        <h2 id="sponsor-tiers-heading" className="sponsor-tiers__title">
-          Nuestros Planes de Promoción
-        </h2>
-        <p className="sponsor-tiers__subtitle">
-          Elige el nivel que mejor encaja con tu estrategia de visibilidad
-        </p>
-      </header>
+const renderPrice = (symbol, amount) => (
+  <div className="sponsor-tiers__price">
+    <span className="sponsor-tiers__price-sign">{symbol}</span>
+    <span className="sponsor-tiers__price-amount">{formatNumber(amount)}</span>
+  </div>
+);
 
-      {/* Platinum — full-width featured */}
-      <AnimationWrapper animation="fade-up" duration={800}>
-        <div className="sponsor-tiers__featured">
-          <div className="sponsor-tiers__featured-inner">
-            <div className="sponsor-tiers__tier-side">
-              <span className="sponsor-tiers__tier-label sponsor-tiers__tier-label--gold">
-                {platinum.name}
-              </span>
-              <div className="sponsor-tiers__price">
-                <span className="sponsor-tiers__price-sign">€</span>
-                <span className="sponsor-tiers__price-amount">{formatPrice(platinum.price)}</span>
-              </div>
-              <span className="sponsor-tiers__price-sub">inversión</span>
-              <a
-                href={`mailto:${CONTACT_EMAIL}?subject=Patrocinio Platinum`}
-                className="sponsor-tiers__cta sponsor-tiers__cta--gold"
-                aria-label="Contactar sobre el plan Platinum"
+const PricingTable = () => {
+  const [activeMode, setActiveMode] = useState(cityModes[0]);
+  const featuredPlan = plans.find((plan) => plan.featured);
+  const trackPlan = plans.find((plan) => plan.track);
+  const standardPlans = plans.filter((plan) => !plan.featured && !plan.track);
+
+  return (
+    <section className="sponsor-tiers" id="patrocinio" aria-labelledby="sponsor-tiers-heading">
+      <div className="sponsor-tiers__container">
+        <header className="sponsor-tiers__header">
+          <h2 id="sponsor-tiers-heading" className="sponsor-tiers__title">
+            Nuestros Planes de Promoción
+          </h2>
+          <p className="sponsor-tiers__subtitle">
+            Selecciona ciudad para ver precios y beneficios físicos aplicables.
+          </p>
+          <div className="sponsor-tiers__city-tabs" role="tablist" aria-label="Selector de patrocinio por ciudad">
+            {cityModes.map((mode) => (
+              <button
+                key={mode.id}
+                type="button"
+                className={`sponsor-tiers__city-tab${activeMode.id === mode.id ? ' sponsor-tiers__city-tab--active' : ''}`}
+                onClick={() => setActiveMode(mode)}
+                role="tab"
+                aria-selected={activeMode.id === mode.id}
               >
-                Contactar
-              </a>
-            </div>
-            <ul className="sponsor-tiers__features sponsor-tiers__features--grid" aria-label="Beneficios Platinum">
-              {platinum.features.map((f, i) => (
-                <li key={i} className="sponsor-tiers__feature">
-                  <BsCheckCircleFill className="sponsor-tiers__check sponsor-tiers__check--gold" aria-hidden="true" />
-                  <span>{f}</span>
-                </li>
-              ))}
-            </ul>
+                {mode.label}
+              </button>
+            ))}
           </div>
-        </div>
-      </AnimationWrapper>
+          <p className="sponsor-tiers__city-copy">
+            {activeMode.copy}
+          </p>
+          <p className="sponsor-tiers__city-note">
+            Tipo de cambio fijo: 1 EUR = {EUR_TO_AED.toFixed(2)} AED y 1 EUR = {EUR_TO_USD.toFixed(2)} USD (redondeo a {ROUND_STEP}).
+          </p>
+        </header>
 
-      {/* Track Sponsor — centered, exclusive */}
-      <AnimationWrapper animation="fade-up" duration={800}>
-        <div className="sponsor-tiers__track-wrap">
-          <div className="sponsor-tiers__track">
-            <div className="sponsor-tiers__exclusive-badge" aria-label="Exclusivo, solo 2 disponibles">
-              <BsStar aria-hidden="true" />
-              EXCLUSIVO · SOLO 2 DISPONIBLES
-            </div>
-            <div className="sponsor-tiers__featured-inner">
-              <div className="sponsor-tiers__tier-side">
-                <span className="sponsor-tiers__tier-label sponsor-tiers__tier-label--cyan">
-                  {track.name}
-                </span>
-                <div className="sponsor-tiers__price">
-                  <span className="sponsor-tiers__price-sign">€</span>
-                  <span className="sponsor-tiers__price-amount">{formatPrice(track.price)}</span>
+        {featuredPlan && (
+          <AnimationWrapper animation="fade-up" duration={800}>
+            <div className="sponsor-tiers__featured">
+              <div className="sponsor-tiers__featured-inner">
+                <div className="sponsor-tiers__tier-side">
+                  <span className="sponsor-tiers__tier-label sponsor-tiers__tier-label--gold">{featuredPlan.name}</span>
+                  {renderPrice(activeMode.currencySymbol, activeMode.computePrice(featuredPlan.eurPrice))}
+                  <span className="sponsor-tiers__price-sub">{activeMode.currencyCode} · inversión</span>
+                  <a
+                    href={`mailto:${CONTACT_EMAIL}?subject=Patrocinio ${activeMode.subjectPrefix} ${featuredPlan.name}`}
+                    className="sponsor-tiers__cta sponsor-tiers__cta--gold"
+                    aria-label={`Contactar sobre el plan ${featuredPlan.name} en ${activeMode.subjectPrefix}`}
+                  >
+                    Contactar
+                  </a>
                 </div>
-                <span className="sponsor-tiers__price-sub">inversión</span>
+                <ul className="sponsor-tiers__features sponsor-tiers__features--grid" aria-label={`Beneficios ${featuredPlan.name}`}>
+                  {featuredPlan.features.map((feature) => (
+                    <li key={feature} className="sponsor-tiers__feature">
+                      <BsCheckCircleFill className="sponsor-tiers__check sponsor-tiers__check--gold" aria-hidden="true" />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          </AnimationWrapper>
+        )}
+
+        {trackPlan && (
+          <AnimationWrapper animation="fade-up" duration={800}>
+            <div className="sponsor-tiers__track-wrap">
+              <div className="sponsor-tiers__track">
+                <div className="sponsor-tiers__exclusive-badge" aria-label="Exclusivo, solo 2 disponibles">
+                  <BsStar aria-hidden="true" />
+                  EXCLUSIVO · SOLO 2 DISPONIBLES
+                </div>
+                <div className="sponsor-tiers__featured-inner">
+                  <div className="sponsor-tiers__tier-side">
+                    <span className="sponsor-tiers__tier-label sponsor-tiers__tier-label--cyan">{trackPlan.name}</span>
+                    {renderPrice(activeMode.currencySymbol, activeMode.computePrice(trackPlan.eurPrice))}
+                    <span className="sponsor-tiers__price-sub">{activeMode.currencyCode} · inversión</span>
+                    <a
+                      href={`mailto:${CONTACT_EMAIL}?subject=Patrocinio ${activeMode.subjectPrefix} ${trackPlan.name}`}
+                      className="sponsor-tiers__cta sponsor-tiers__cta--outline"
+                      aria-label={`Contactar sobre el plan ${trackPlan.name} en ${activeMode.subjectPrefix}`}
+                    >
+                      Contactar
+                    </a>
+                  </div>
+                  <ul className="sponsor-tiers__features" aria-label={`Beneficios ${trackPlan.name}`}>
+                    {trackPlan.features.map((feature) => (
+                      <li key={feature} className="sponsor-tiers__feature">
+                        <BsCheckCircleFill className="sponsor-tiers__check sponsor-tiers__check--cyan" aria-hidden="true" />
+                        <span>{feature}</span>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              </div>
+            </div>
+          </AnimationWrapper>
+        )}
+
+        <div className="sponsor-tiers__standard-row">
+          {standardPlans.map((plan) => (
+            <AnimationWrapper key={plan.id} animation="fade-up" duration={800}>
+              <div className={`sponsor-tiers__card sponsor-tiers__card--${plan.id}`}>
+                <span className={`sponsor-tiers__tier-label sponsor-tiers__tier-label--${plan.id === 'gold' ? 'amber' : 'slate'}`}>
+                  {plan.name}
+                </span>
+                {renderPrice(activeMode.currencySymbol, activeMode.computePrice(plan.eurPrice))}
+                <span className="sponsor-tiers__price-sub">{activeMode.currencyCode} · inversión</span>
+                <ul className="sponsor-tiers__features" aria-label={`Beneficios ${plan.name}`}>
+                  {plan.features.map((feature) => (
+                    <li key={feature} className="sponsor-tiers__feature">
+                      <BsCheckCircleFill
+                        className={`sponsor-tiers__check sponsor-tiers__check--${plan.id === 'gold' ? 'cyan-dim' : 'slate'}`}
+                        aria-hidden="true"
+                      />
+                      <span>{feature}</span>
+                    </li>
+                  ))}
+                </ul>
                 <a
-                  href={`mailto:${CONTACT_EMAIL}?subject=Patrocinio Track Sponsor`}
-                  className="sponsor-tiers__cta sponsor-tiers__cta--outline"
-                  aria-label="Contactar sobre el plan Track Sponsor"
+                  href={`mailto:${CONTACT_EMAIL}?subject=Patrocinio ${activeMode.subjectPrefix} ${plan.name}`}
+                  className="sponsor-tiers__cta sponsor-tiers__cta--muted"
+                  aria-label={`Contactar sobre el plan ${plan.name} en ${activeMode.subjectPrefix}`}
                 >
                   Contactar
                 </a>
               </div>
-              <ul className="sponsor-tiers__features" aria-label="Beneficios Track Sponsor">
-                {track.features.map((f, i) => (
-                  <li key={i} className="sponsor-tiers__feature">
-                    <BsCheckCircleFill className="sponsor-tiers__check sponsor-tiers__check--cyan" aria-hidden="true" />
-                    <span>{f}</span>
-                  </li>
-                ))}
-              </ul>
-            </div>
-          </div>
+            </AnimationWrapper>
+          ))}
         </div>
-      </AnimationWrapper>
 
-      {/* Gold / Silver / Virtual-Only */}
-      <div className="sponsor-tiers__standard-row">
-        {standard.map((plan) => (
-          <AnimationWrapper key={plan.id} animation="fade-up" duration={800}>
-            <div className={`sponsor-tiers__card sponsor-tiers__card--${plan.id}`}>
-              <span className={`sponsor-tiers__tier-label sponsor-tiers__tier-label--${plan.id === 'gold' ? 'amber' : 'slate'}`}>
-                {plan.name}
-              </span>
-              <div className="sponsor-tiers__price">
-                <span className="sponsor-tiers__price-sign">€</span>
-                <span className="sponsor-tiers__price-amount">{formatPrice(plan.price)}</span>
-              </div>
-              <span className="sponsor-tiers__price-sub">inversión</span>
-              <ul className="sponsor-tiers__features" aria-label={`Beneficios ${plan.name}`}>
-                {plan.features.map((f, i) => (
-                  <li key={i} className="sponsor-tiers__feature">
-                    <BsCheckCircleFill
-                      className={`sponsor-tiers__check sponsor-tiers__check--${plan.id === 'gold' ? 'cyan-dim' : 'slate'}`}
-                      aria-hidden="true"
-                    />
-                    <span>{f}</span>
-                  </li>
-                ))}
-              </ul>
-              <a
-                href={`mailto:${CONTACT_EMAIL}?subject=Patrocinio ${plan.name}`}
-                className="sponsor-tiers__cta sponsor-tiers__cta--muted"
-                aria-label={`Contactar sobre el plan ${plan.name}`}
-              >
-                Contactar
-              </a>
-            </div>
-          </AnimationWrapper>
-        ))}
+        <div className="sponsor-tiers__startup">
+          <h3>Startup Pack</h3>
+          <p>
+            Si eres startup, recupera el acceso rápido al formulario de elegibilidad y aplica hoy.
+          </p>
+          <Link to="/startup-pack" className="sponsor-tiers__cta sponsor-tiers__cta--gold">
+            Ir a Startup Pack
+          </Link>
+        </div>
       </div>
-
-    </div>
-  </section>
-);
+    </section>
+  );
+};
 
 export default PricingTable;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -25,6 +25,8 @@
     "address": "Address",
     "addressLine1": "Rey Juan Carlos University Móstoles campus",
     "addressLine2": "Av. del Alcalde de Móstoles, s/n, 28933 Móstoles, Madrid",
+    "dubaiAddressLine1": "Dubai, United Arab Emirates",
+    "dubaiAddressLine2": "Venue to be confirmed",
     "contacts": "Contacts",
     "links": "Links",
     "privacyPolicy": "Privacy Policy",
@@ -533,8 +535,8 @@
   },
   "speakers": {
     "title": "Meet Our Speakers",
-    "metaTitle": "Speakers at X-Ops Conference Madrid 2025",
-    "metaDesc": "Discover the experts sharing their knowledge in DevOps, DevSecOps, AIOps and MLOps at X-Ops Conference Madrid 2025.",
+    "metaTitle": "X-Ops Conference & Summit 2026 · Madrid and Dubai",
+    "metaDesc": "Discover the X-Ops 2026 ecosystem in Madrid and Dubai: executive Summit plus technical Conference.",
     "talk": "Talk"
   }
 }

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -25,6 +25,8 @@
     "address": "Dirección",
     "addressLine1": "Universidad Rey Juan Carlos campus Móstoles",
     "addressLine2": "Av. del Alcalde de Móstoles, s/n, 28933 Móstoles, Madrid",
+    "dubaiAddressLine1": "Dubai, Emiratos Árabes Unidos",
+    "dubaiAddressLine2": "Venue por confirmar",
     "contacts": "Contactos",
     "links": "Enlaces",
     "privacyPolicy": "Política de Privacidad",
@@ -527,8 +529,8 @@
   },
   "speakers": {
     "title": "Conoce a Nuestros Ponentes",
-    "metaTitle": "Ponentes de la X-Ops Conference Madrid 2025",
-    "metaDesc": "Descubre a los expertos que compartirán sus conocimientos en DevOps, DevSecOps, AIOps y MLOps en la X-Ops Conference Madrid 2025.",
+    "metaTitle": "X-Ops Conference & Summit 2026 · Madrid y Dubai",
+    "metaDesc": "Descubre el ecosistema X-Ops 2026 en Madrid y Dubai: Summit ejecutivo y Conference técnica.",
     "talk": "Charla"
   }
 }

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -20,7 +20,7 @@ const Home = () => {
   return (
     <>
       <SEO
-        title="X-Ops Conference Madrid 2026 · DevOps, DevSecOps, AIOps & MLOps"
+        title="X-Ops Conference & Summit 2026 · Madrid y Dubai"
         description="X-Ops Conference: el mayor evento de DevOps, DevSecOps, AIOps, MLOps y Platform Engineering en España. Madrid y Dubai 2026 · Summit ejecutivo + Conference técnica."
         path="/"
         image="https://xopsconference.com/icon-512x512.png"
@@ -33,20 +33,20 @@ const Home = () => {
         structuredData={{
           "@context": "https://schema.org",
           "@type": "Event",
-          "name": "X-Ops Conference Madrid 2026",
-          "description": "El mayor evento de DevOps, DevSecOps, AIOps, MLOps y Platform Engineering en España. Summit + Conference.",
-          "startDate": "2026-11-19",
+          "name": "X-Ops Conference & Summit 2026 · Madrid y Dubai",
+          "description": "Ecosistema X-Ops 2026 en Madrid y Dubai: Summit ejecutivo y Conference técnica.",
+          "startDate": "2026-10-15",
           "endDate": "2026-11-21",
           "eventStatus": "https://schema.org/EventScheduled",
           "eventAttendanceMode": "https://schema.org/OfflineEventAttendanceMode",
           "location": {
             "@type": "Place",
-            "name": "URJC Madrid",
+            "name": "Madrid y Dubai",
             "address": {
               "@type": "PostalAddress",
-              "addressLocality": "Madrid",
-              "addressRegion": "Madrid",
-              "addressCountry": "ES"
+              "addressLocality": "Madrid / Dubai",
+              "addressRegion": "Madrid / Dubai",
+              "addressCountry": "ES / AE"
             }
           },
           "organizer": {

--- a/src/pages/tickets/XOpsEventDetail.jsx
+++ b/src/pages/tickets/XOpsEventDetail.jsx
@@ -1,143 +1,189 @@
 import { Link } from 'react-router-dom';
-import { Container, Row, Col, Card, Tab, Tabs, Button } from 'react-bootstrap';
+import { Container, Row, Col, Card, Tab, Tabs } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import { FaMapMarkerAlt, FaCalendarAlt, FaClock, FaMicrophoneAlt, FaLaptopCode, FaNetworkWired, FaCheckCircle, FaUsers } from 'react-icons/fa';
+import { FaMapMarkerAlt, FaCalendarAlt, FaClock, FaMicrophoneAlt, FaCheckCircle, FaUsers } from 'react-icons/fa';
 import SEO from '../../components/SEO';
 import './XOpsEventDetail.css';
 
 const XOpsEventDetail = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const isEs = i18n.language === 'es';
 
-  const agenda = {
-    day1: [
-      { time: '09:00', title: 'Registration & Welcome Coffee', type: 'networking' },
-      { time: '10:00', title: 'Opening Keynote: The Future of Tech Operations', type: 'keynote', speaker: 'TBA' },
-      { time: '11:30', title: 'DevSecOps in the Age of AI', type: 'session' },
-      { time: '12:30', title: 'Networking Lunch', type: 'break' },
-      { time: '14:00', title: 'Zero Trust Architecture Workshop', type: 'workshop' },
-      { time: '15:30', title: 'Platform Engineering at Scale', type: 'session' },
-      { time: '17:00', title: 'Executive Roundtable: CIO Priorities 2027', type: 'roundtable' },
-      { time: '19:00', title: 'Welcome Reception', type: 'social' },
-    ],
-    day2: [
-      { time: '09:00', title: 'Morning Coffee & Networking', type: 'networking' },
-      { time: '10:00', title: 'Keynote: Scaling Infrastructure for AI Workloads', type: 'keynote', speaker: 'TBA' },
-      { time: '11:30', title: 'Incident Response & Chaos Engineering', type: 'session' },
-      { time: '12:30', title: 'Networking Lunch', type: 'break' },
-      { time: '14:00', title: 'SRE Best Practices Panel', type: 'panel' },
-      { time: '15:30', title: 'Cloud Cost Optimization Strategies', type: 'session' },
-      { time: '17:00', title: 'Closing Keynote: Building Resilient Organizations', type: 'keynote', speaker: 'TBA' },
-      { time: '18:30', title: 'Gala Dinner', type: 'social' },
-    ],
-    day3: [
-      { time: '09:00', title: 'Hands-on Labs: Kubernetes Security', type: 'workshop' },
-      { time: '11:00', title: 'Observability & Monitoring Workshop', type: 'workshop' },
-      { time: '13:00', title: 'Farewell Lunch & Networking', type: 'break' },
-      { time: '14:30', title: 'Closing Remarks & Awards', type: 'closing' },
-    ],
-  };
+  const copy = isEs
+    ? {
+        seoTitle: 'X-Ops Dubai 2026 · Summit + Conference',
+        seoDescription: 'Detalle oficial de X-Ops Dubai 2026. Summit y Conference diferenciados por bloques, con sede pendiente de confirmación.',
+        home: 'Inicio',
+        page: 'X-Ops Dubai 2026',
+        badge: '15-17 de octubre de 2026',
+        title: 'X-Ops Dubai 2026',
+        navSummit: 'Ver bloque Summit',
+        navConference: 'Ver bloque Conference',
+        summitTitle: 'X-Ops Summit Dubai 2026',
+        summitSubtitle: '15 y 16 de octubre · Track ejecutivo',
+        conferenceTitle: 'X-Ops Conference Dubai 2026',
+        conferenceSubtitle: '17 de octubre · Track técnico',
+        speakersTitle: 'Speakers',
+        speakersSubtitle: 'Lineup en confirmación. Compartiremos ponentes conforme se cierre agenda por bloque.',
+        venueTitle: 'Sede Dubai',
+        venueName: 'Venue por confirmar',
+        venueDescription: 'La sede oficial de Dubai se anunciará próximamente. El programa mantiene fechas activas y plazas limitadas.',
+        venueMap: '📍 Dubai, EAU',
+        venueMapNote: 'Mapa disponible cuando se confirme la sede',
+        sponsorTitle: '¿Quieres patrocinar Dubai?',
+        sponsorText: 'Accede a los planes por ciudad en la sección de patrocinio (Madrid / Dubai / Ambas).',
+        sponsorCta: 'Ver patrocinio por ciudad',
+        ticketCtaTitle: 'Reserva tu entrada para Dubai 2026',
+        ticketCtaText: 'Entradas independientes por ciudad y por tipo de evento (Summit o Conference).',
+      }
+    : {
+        seoTitle: 'X-Ops Dubai 2026 · Summit + Conference',
+        seoDescription: 'Official detail page for X-Ops Dubai 2026. Summit and Conference split into separate blocks, venue pending confirmation.',
+        home: 'Home',
+        page: 'X-Ops Dubai 2026',
+        badge: 'October 15-17, 2026',
+        title: 'X-Ops Dubai 2026',
+        navSummit: 'View Summit block',
+        navConference: 'View Conference block',
+        summitTitle: 'X-Ops Summit Dubai 2026',
+        summitSubtitle: 'October 15 & 16 · Executive track',
+        conferenceTitle: 'X-Ops Conference Dubai 2026',
+        conferenceSubtitle: 'October 17 · Technical track',
+        speakersTitle: 'Speakers',
+        speakersSubtitle: 'Lineup in progress. Speakers will be announced as each block is finalized.',
+        venueTitle: 'Dubai venue',
+        venueName: 'Venue to be confirmed',
+        venueDescription: 'The official Dubai venue will be announced soon. Dates remain active and seats are limited.',
+        venueMap: '📍 Dubai, UAE',
+        venueMapNote: 'Map available once venue is confirmed',
+        sponsorTitle: 'Want to sponsor Dubai?',
+        sponsorText: 'Access city-based plans in sponsorship section (Madrid / Dubai / Both).',
+        sponsorCta: 'View city sponsorship plans',
+        ticketCtaTitle: 'Reserve your ticket for Dubai 2026',
+        ticketCtaText: 'Tickets are independent by city and event type (Summit or Conference).',
+      };
 
-  const speakers = [
-    { name: 'Keynote Speakers', role: 'TBA - Industry Leaders', company: 'Fortune 500 CTOs & Global Visionaries' },
-    { name: 'DevSecOps Track', role: 'Security Leaders', company: 'TBA' },
-    { name: 'Platform Engineering', role: 'Infrastructure Experts', company: 'TBA' },
-  ];
+  const summitAgenda = isEs
+    ? {
+        day1: [
+          { time: '09:00', title: 'Registro ejecutivo y café de bienvenida' },
+          { time: '10:00', title: 'Keynote: liderazgo tecnológico en mercados de alto crecimiento' },
+          { time: '12:00', title: 'Mesa redonda C-Level: resiliencia operativa y riesgo' },
+          { time: '14:00', title: 'Almuerzo de networking' },
+          { time: '16:00', title: 'Sesión privada: hoja de ruta 2027 para líderes de plataforma' },
+        ],
+        day2: [
+          { time: '09:30', title: 'Breakfast briefing con líderes de la región' },
+          { time: '11:00', title: 'Panel: gobierno, compliance y seguridad en escala multi-país' },
+          { time: '13:00', title: 'Roundtables por industria' },
+          { time: '16:30', title: 'Cierre ejecutivo y próximos pasos' },
+        ],
+      }
+    : {
+        day1: [
+          { time: '09:00', title: 'Executive registration and welcome coffee' },
+          { time: '10:00', title: 'Keynote: tech leadership in high-growth markets' },
+          { time: '12:00', title: 'C-Level roundtable: operational resilience and risk' },
+          { time: '14:00', title: 'Networking lunch' },
+          { time: '16:00', title: 'Private session: 2027 platform leadership roadmap' },
+        ],
+        day2: [
+          { time: '09:30', title: 'Breakfast briefing with regional leaders' },
+          { time: '11:00', title: 'Panel: governance, compliance and security at multi-country scale' },
+          { time: '13:00', title: 'Industry roundtables' },
+          { time: '16:30', title: 'Executive closing and next steps' },
+        ],
+      };
+
+  const conferenceAgenda = isEs
+    ? [
+        { time: '09:00', title: 'Apertura técnica y contexto de plataforma' },
+        { time: '10:00', title: 'Sesión: DevSecOps para plataformas cloud-native' },
+        { time: '11:30', title: 'Sesión: observabilidad práctica para equipos de alta velocidad' },
+        { time: '13:00', title: 'Pausa networking' },
+        { time: '14:30', title: 'Workshop: fiabilidad, incident response y mejora continua' },
+        { time: '16:30', title: 'Cierre técnico y roadmap de comunidad' },
+      ]
+    : [
+        { time: '09:00', title: 'Technical opening and platform context' },
+        { time: '10:00', title: 'Session: DevSecOps for cloud-native platforms' },
+        { time: '11:30', title: 'Session: practical observability for high-velocity teams' },
+        { time: '13:00', title: 'Networking break' },
+        { time: '14:30', title: 'Workshop: reliability, incident response and continuous improvement' },
+        { time: '16:30', title: 'Technical closing and community roadmap' },
+      ];
+
+  const speakers = isEs
+    ? [
+        { name: 'Track Summit', role: 'Líderes C-Level', company: 'Confirmación en curso' },
+        { name: 'Track Conference', role: 'Referentes de ingeniería', company: 'Confirmación en curso' },
+        { name: 'Panel regional', role: 'Expertos MENA y Europa', company: 'Confirmación en curso' },
+      ]
+    : [
+        { name: 'Summit track', role: 'C-Level leaders', company: 'Lineup in progress' },
+        { name: 'Conference track', role: 'Engineering leaders', company: 'Lineup in progress' },
+        { name: 'Regional panel', role: 'MENA and Europe experts', company: 'Lineup in progress' },
+      ];
 
   return (
     <>
       <SEO
-        title="X-Ops Conference Dubai 2026 - Event Details"
-        description="Full event details for X-Ops Conference Dubai 2026. October 15-17, Dubai, UAE. Agenda, speakers, venue information."
+        title={copy.seoTitle}
+        description={copy.seoDescription}
         path="/events/x-ops-conference-dubai-2026"
       />
       <div className="xops-detail">
-        {/* Header */}
         <section className="xops-detail-header">
           <Container>
             <Row>
               <Col>
                 <nav className="xops-breadcrumb">
-                  <Link to="/">Home</Link> / <Link to="/events/x-ops-conference-dubai-2026">X-Ops Dubai 2026</Link>
+                  <Link to="/">{copy.home}</Link> / <Link to="/events/x-ops-conference-dubai-2026">{copy.page}</Link>
                 </nav>
-                <span className="xops-detail-badge">October 15-17, 2026</span>
-                <h1>X-Ops Conference Dubai 2026</h1>
+                <span className="xops-detail-badge">{copy.badge}</span>
+                <h1>{copy.title}</h1>
                 <div className="xops-detail-meta">
                   <span><FaMapMarkerAlt /> Dubai, UAE</span>
                   <span><FaCalendarAlt /> 3 Days</span>
                   <span><FaUsers /> 500+ Leaders</span>
                 </div>
+                <div className="xops-hero-cta" style={{ marginTop: '1rem', display: 'flex', gap: '0.75rem', flexWrap: 'wrap' }}>
+                  <a href="#summit-dubai" className="xops-btn-outline">{copy.navSummit}</a>
+                  <a href="#conference-dubai" className="xops-btn-outline">{copy.navConference}</a>
+                </div>
               </Col>
             </Row>
           </Container>
         </section>
 
-        {/* Quick Stats */}
-        <section className="xops-stats">
-          <Container>
-            <Row className="text-center">
-              <Col xs={6} md={3} className="mb-3">
-                <div className="xops-stat">3</div>
-                <div className="xops-stat-label">Days</div>
-              </Col>
-              <Col xs={6} md={3} className="mb-3">
-                <div className="xops-stat">30+</div>
-                <div className="xops-stat-label">Sessions</div>
-              </Col>
-              <Col xs={6} md={3} className="mb-3">
-                <div className="xops-stat">20+</div>
-                <div className="xops-stat-label">Speakers</div>
-              </Col>
-              <Col xs={6} md={3} className="mb-3">
-                <div className="xops-stat">500+</div>
-                <div className="xops-stat-label">Attendees</div>
-              </Col>
-            </Row>
-          </Container>
-        </section>
-
-        {/* Agenda */}
-        <section className="xops-agenda">
+        <section id="summit-dubai" className="xops-agenda">
           <Container>
             <Row className="mb-4">
               <Col>
-                <h2><FaClock /> Agenda</h2>
+                <h2><FaClock /> {copy.summitTitle}</h2>
+                <p className="text-muted">{copy.summitSubtitle}</p>
               </Col>
             </Row>
-            <Tabs defaultActiveKey="day1" id="agenda-tabs" className="xops-agenda-tabs">
-              <Tab eventKey="day1" title="Day 1 - Oct 15">
+            <Tabs defaultActiveKey="summit-day1" id="summit-agenda-tabs" className="xops-agenda-tabs">
+              <Tab eventKey="summit-day1" title={isEs ? 'Día 1 · 15 Oct' : 'Day 1 · Oct 15'}>
                 <div className="xops-agenda-list">
-                  {agenda.day1.map((item, idx) => (
-                    <div key={idx} className={`xops-agenda-item xops-agenda-${item.type}`}>
+                  {summitAgenda.day1.map((item, idx) => (
+                    <div key={idx} className="xops-agenda-item xops-agenda-session">
                       <div className="xops-agenda-time">{item.time}</div>
                       <div className="xops-agenda-content">
                         <div className="xops-agenda-title">{item.title}</div>
-                        {item.speaker && <div className="xops-agenda-speaker">{item.speaker}</div>}
                       </div>
                     </div>
                   ))}
                 </div>
               </Tab>
-              <Tab eventKey="day2" title="Day 2 - Oct 16">
+              <Tab eventKey="summit-day2" title={isEs ? 'Día 2 · 16 Oct' : 'Day 2 · Oct 16'}>
                 <div className="xops-agenda-list">
-                  {agenda.day2.map((item, idx) => (
-                    <div key={idx} className={`xops-agenda-item xops-agenda-${item.type}`}>
+                  {summitAgenda.day2.map((item, idx) => (
+                    <div key={idx} className="xops-agenda-item xops-agenda-session">
                       <div className="xops-agenda-time">{item.time}</div>
                       <div className="xops-agenda-content">
                         <div className="xops-agenda-title">{item.title}</div>
-                        {item.speaker && <div className="xops-agenda-speaker">{item.speaker}</div>}
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </Tab>
-              <Tab eventKey="day3" title="Day 3 - Oct 17">
-                <div className="xops-agenda-list">
-                  {agenda.day3.map((item, idx) => (
-                    <div key={idx} className={`xops-agenda-item xops-agenda-${item.type}`}>
-                      <div className="xops-agenda-time">{item.time}</div>
-                      <div className="xops-agenda-content">
-                        <div className="xops-agenda-title">{item.title}</div>
-                        {item.speaker && <div className="xops-agenda-speaker">{item.speaker}</div>}
                       </div>
                     </div>
                   ))}
@@ -147,75 +193,95 @@ const XOpsEventDetail = () => {
           </Container>
         </section>
 
-        {/* Speakers */}
+        <section id="conference-dubai" className="xops-agenda">
+          <Container>
+            <Row className="mb-4">
+              <Col>
+                <h2><FaClock /> {copy.conferenceTitle}</h2>
+                <p className="text-muted">{copy.conferenceSubtitle}</p>
+              </Col>
+            </Row>
+            <div className="xops-agenda-list">
+              {conferenceAgenda.map((item, idx) => (
+                <div key={idx} className="xops-agenda-item xops-agenda-session">
+                  <div className="xops-agenda-time">{item.time}</div>
+                  <div className="xops-agenda-content">
+                    <div className="xops-agenda-title">{item.title}</div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </Container>
+        </section>
+
         <section className="xops-speakers">
           <Container>
             <Row className="mb-4">
               <Col>
-                <h2><FaMicrophoneAlt /> Speakers</h2>
-                <p className="text-muted">World-class technology leaders sharing insights on the future of tech operations.</p>
+                <h2><FaMicrophoneAlt /> {copy.speakersTitle}</h2>
+                <p className="text-muted">{copy.speakersSubtitle}</p>
               </Col>
             </Row>
             <Row>
-              {speakers.map((s, idx) => (
+              {speakers.map((speaker, idx) => (
                 <Col md={4} key={idx} className="mb-4">
                   <Card className="xops-speaker-card">
                     <Card.Body>
                       <div className="xops-speaker-avatar">👤</div>
-                      <h4>{s.name}</h4>
-                      <p className="text-muted mb-1">{s.role}</p>
-                      <p className="xops-speaker-company">{s.company}</p>
+                      <h4>{speaker.name}</h4>
+                      <p className="text-muted mb-1">{speaker.role}</p>
+                      <p className="xops-speaker-company">{speaker.company}</p>
                     </Card.Body>
                   </Card>
                 </Col>
               ))}
             </Row>
-            <Row className="mt-4">
-              <Col className="text-center">
-                <p className="text-muted">More speakers to be announced. Follow our updates for the latest speaker lineup.</p>
-              </Col>
-            </Row>
           </Container>
         </section>
 
-        {/* Venue */}
         <section className="xops-venue">
           <Container>
             <Row>
               <Col md={6}>
-                <h2><FaMapMarkerAlt /> Venue</h2>
-                <h4>Dubai World Trade Center</h4>
-                <p>Sheikh Zayed Rd - Trade Centre 2<br />Dubai, United Arab Emirates</p>
-                <p className="text-muted">The Dubai World Trade Center offers world-class facilities in the heart of Dubai's business district, easily accessible from all major hotels and the airport.</p>
+                <h2><FaMapMarkerAlt /> {copy.venueTitle}</h2>
+                <h4>{copy.venueName}</h4>
+                <p>{copy.venueDescription}</p>
                 <div className="xops-venue-features">
-                  <div><FaCheckCircle /> Premium Conference Facilities</div>
-                  <div><FaCheckCircle /> 5-Star Hotels Walking Distance</div>
-                  <div><FaCheckCircle /> Metro Station Nearby</div>
-                  <div><FaCheckCircle /> Airport Transfer Available</div>
+                  <div><FaCheckCircle /> {isEs ? 'Fechas confirmadas' : 'Dates confirmed'}</div>
+                  <div><FaCheckCircle /> {isEs ? 'Actualizaciones por email' : 'Email updates enabled'}</div>
+                  <div><FaCheckCircle /> {isEs ? 'Aforo limitado' : 'Limited capacity'}</div>
                 </div>
               </Col>
               <Col md={6}>
                 <div className="xops-venue-map-placeholder">
-                  <p>📍 Dubai World Trade Center</p>
-                  <p className="text-muted">Map integration available soon</p>
+                  <p>{copy.venueMap}</p>
+                  <p className="text-muted">{copy.venueMapNote}</p>
                 </div>
               </Col>
             </Row>
           </Container>
         </section>
 
-        {/* CTA */}
         <section className="xops-detail-cta">
           <Container className="text-center">
-            <h2>Ready to Join X-Ops Dubai 2026?</h2>
-            <p>Secure your spot at the premier technology leadership event in the Middle East.</p>
-            <Link to="/events/x-ops-conference-dubai-2026/buy" className="xops-btn-primary">
-              {t('tickets.buyTickets')}
+            <h2>{copy.sponsorTitle}</h2>
+            <p>{copy.sponsorText}</p>
+            <Link to="/#patrocinio" className="xops-btn-outline">
+              {copy.sponsorCta}
             </Link>
           </Container>
         </section>
 
-        {/* Sophia Footer Note */}
+        <section className="xops-detail-cta">
+          <Container className="text-center">
+            <h2>{copy.ticketCtaTitle}</h2>
+            <p>{copy.ticketCtaText}</p>
+            <Link to="/events/x-ops-conference-dubai-2026/buy" className="xops-btn-primary">
+              {t('tickets.event.buyTickets')}
+            </Link>
+          </Container>
+        </section>
+
         <section className="xops-sophia-note">
           <Container>
             <p className="text-center">

--- a/src/pages/tickets/XOpsHome.jsx
+++ b/src/pages/tickets/XOpsHome.jsx
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import { Container, Row, Col, Card, Button } from 'react-bootstrap';
+import { Container, Row, Col, Card } from 'react-bootstrap';
 import { useTranslation } from 'react-i18next';
 import { FaMapMarkerAlt, FaCalendarAlt, FaUsers, FaMicrophoneAlt, FaShieldAlt } from 'react-icons/fa';
 import SEO from '../../components/SEO';
@@ -34,10 +34,10 @@ const XOpsHome = () => {
                 </p>
                 <div className="xops-hero-cta">
                   <Link to="/events/x-ops-conference-dubai-2026/buy" className="xops-btn-primary">
-                    {t('tickets.buyNow')}
+                    {t('tickets.event.buyNow')}
                   </Link>
                   <Link to="/events/x-ops-conference-dubai-2026" className="xops-btn-outline">
-                    {t('tickets.viewDetails')}
+                    {t('tickets.event.viewDetails')}
                   </Link>
                 </div>
                 <div className="xops-hero-meta">
@@ -100,7 +100,7 @@ const XOpsHome = () => {
               </Col>
               <Col md={4} className="text-md-end">
                 <Link to="/events/x-ops-conference-dubai-2026/buy" className="xops-btn-primary">
-                  {t('tickets.buyTickets')}
+                  {t('tickets.event.buyTickets')}
                 </Link>
               </Col>
             </Row>

--- a/src/styles/PricingTable.css
+++ b/src/styles/PricingTable.css
@@ -34,6 +34,44 @@
   line-height: 1.65;
 }
 
+.sponsor-tiers__city-tabs {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+.sponsor-tiers__city-tab {
+  background: transparent;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  color: #94a3b8;
+  border-radius: 999px;
+  padding: 8px 14px;
+  font-size: 0.8rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.sponsor-tiers__city-tab--active {
+  color: #0A0F2E;
+  background: #FFD600;
+  border-color: #FFD600;
+}
+
+.sponsor-tiers__city-copy {
+  margin-top: 12px;
+  margin-bottom: 6px;
+  color: #B0BEC5;
+  font-size: 0.9rem;
+}
+
+.sponsor-tiers__city-note {
+  color: #64748b;
+  font-size: 0.8rem;
+  margin-bottom: 0;
+}
+
 /* ── Platinum (featured, full-width) ────────────────────────────── */
 .sponsor-tiers__featured {
   background: #111840;
@@ -284,6 +322,26 @@
 .sponsor-tiers__cta:focus-visible {
   outline: 2px solid #00BCD4;
   outline-offset: 3px;
+}
+
+.sponsor-tiers__startup {
+  margin-top: 28px;
+  border: 1px solid rgba(0, 188, 212, 0.25);
+  border-radius: 16px;
+  padding: 24px;
+  background: #111840;
+  text-align: center;
+}
+
+.sponsor-tiers__startup h3 {
+  color: #f8fafc;
+  margin-bottom: 10px;
+  font-weight: 800;
+}
+
+.sponsor-tiers__startup p {
+  color: #B0BEC5;
+  margin-bottom: 16px;
 }
 
 /* ── Responsive ─────────────────────────────────────────────────── */


### PR DESCRIPTION
… clarity

- Create unified Dubai detail page with separate Summit (#summit-dubai) and Conference (#conference-dubai) sections
- Fix venue state across site: Dubai venue marked 'por confirmar' in both home and detail pages
- Update site-wide title/SEO to '2026 Madrid y Dubai' with correct schema dates
- Implement sponsorship tabs by city (Madrid/Dubai/Ambas) with fixed currency conversion (EUR→AED 4.00, EUR→USD 1.10, -10% combined)
- Fix broken translation key: use tickets.event.* for CTA labels, not tickets.*
- Restore Startup Pack visibility with direct CTA in sponsorship section
- Add clarity on ticket independence: one entry per city/event type
- Update footer to show Dubai address when on Dubai route
- Implement i18n for Dubai footer address with Spanish/English variants

Build: ✅ Passes; Tests: ✅ 7/7 pass; Lint: ✅ 0 errors